### PR TITLE
Add panel semi-colon

### DIFF
--- a/dts/sdm450-motorola-ali.dts
+++ b/dts/sdm450-motorola-ali.dts
@@ -21,7 +21,7 @@
 		qcom,mdss_dsi_mot_tianma_565_1080p_vid_v0 {
 			compatible = "motorola,ali-panel-tianma";
 		};
-  }
+  };
   
   // TODO: this may not be necessary...
 	soc {


### PR DESCRIPTION
This fixes the broken build. The panel node was missing a semi-colon.